### PR TITLE
Fixed controller support on visionOS

### DIFF
--- a/Moonlight Vision/MainContentView.swift
+++ b/Moonlight Vision/MainContentView.swift
@@ -1,6 +1,7 @@
 //
 
 import SwiftUI
+import GameController
 
 struct MainContentView: View {
     @EnvironmentObject private var viewModel: MainViewModel
@@ -17,6 +18,7 @@ struct MainContentView: View {
         if viewModel.activelyStreaming {
             ZStack {
                 StreamView(streamConfig: $viewModel.currentStreamConfig)
+					.handlesGameControllerEvents(matching: .gamepad)
             }
             .onAppear {
                 guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }


### PR DESCRIPTION
  Without marking a view to handle game controller events, some controller buttons continue to be routed system wide.